### PR TITLE
bug: corrected redirect path of successfully deleted key.

### DIFF
--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -163,7 +163,7 @@ router.post('/manage-applications/:appId/:keyType/:keyId/delete/:env', (req, res
   logger.info(`POST request to delete a key: ${req.path}`);
   applicationsDeveloperService.deleteApiKey(appId, keyId, keyType, env)
     .then(response => {
-      res.redirect(302, '/manage-applications');
+      res.redirect(302, `/manage-applications/${appId}/view/${env}`);
     }).catch(
       err => {
         const viewData = {

--- a/test/server/routes/applications.test.js
+++ b/test/server/routes/applications.test.js
@@ -193,10 +193,11 @@ describe('routes/applications.js', () => {
         expect(response).to.have.status(200);
       });
   });
-  it('should serve up the delete a key and then redirect to manage-applications on success', () => {
+  it('should serve up the delete a key and then redirect to view application that owned the key on success', () => {
     const slug = '/manage-applications/mockAppId/mockKeyType/mockKeyId/delete/mockEnv';
     const stubDeleteKey = sinon.stub(ApplicationsDeveloperService.prototype, 'deleteApiKey').returns(Promise.resolve(true));
-    const stubGetApplications = sinon.stub(ApplicationsDeveloperService.prototype, 'getApplicationList').returns(Promise.resolve(true));
+    const stubGetApplications = sinon.stub(ApplicationsDeveloperService.prototype, 'getApplication').returns(Promise.resolve(true));
+    const stubGetApplicationKeyss = sinon.stub(ApplicationsDeveloperService.prototype, 'getKeysForApplication').returns(Promise.resolve(true));
     return request(app)
       .post(slug)
       .set('Cookie', cookieStr)
@@ -204,7 +205,7 @@ describe('routes/applications.js', () => {
         expect(stubLogger).to.have.been.calledTwice;
         expect(stubDeleteKey).to.have.been.calledOnce;
         expect(stubDeleteKey).to.have.been.calledWith('mockAppId', 'mockKeyId', 'mockKeyType', 'mockEnv');
-        expect(response).to.redirectTo(/manage-applications/);
+        expect(response).to.redirectTo(/manage-applications\/mockAppId\/view\/mockEnv/g);
       });
   });
   it('should serve up the delete key page on the delete path when got with an error', () => {


### PR DESCRIPTION
Responding to testing request.
This still does not cover notifications.