### PR TITLE
fix: persist request parameters after failing validation so that the …

### DIFF
--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -294,19 +294,17 @@ router.post('/manage-applications/:appId/:keyType/:keyId/update/:env', (req, res
   const keyId = req.params.keyId;
   const data = req.body;
   const viewData = routeUtils.createViewData('Update Key', 'application-overview', req);
-  viewData.this_data = data;
-  viewData.this_data = {
-    appId: appId,
-    env: env,
-    keyType: keyType,
-    keyId: keyId
-  };
   validator.updateKey(data)
     .then(_ => {
       return applicationsDeveloperService.updateKey(data, appId, keyId, env);
     }).then(_ => {
       return res.redirect(302, `/manage-applications/${appId}/view/${data.keyName}/${env}`);
     }).catch(err => {
+      viewData.this_data = data;
+      viewData.this_data.appId = appId;
+      viewData.this_data.env = env;
+      viewData.this_data.keyType = keyType;
+      viewData.this_data.keyId = keyId;
       viewData.this_errors = routeUtils.processException(err);
       res.render(`${routeViews}/update_key.njk`, viewData);
     });

--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -295,6 +295,12 @@ router.post('/manage-applications/:appId/:keyType/:keyId/update/:env', (req, res
   const data = req.body;
   const viewData = routeUtils.createViewData('Update Key', 'application-overview', req);
   viewData.this_data = data;
+  viewData.this_data = {
+    appId: appId,
+    env: env,
+    keyType: keyType,
+    keyId: keyId
+  };
   validator.updateKey(data)
     .then(_ => {
       return applicationsDeveloperService.updateKey(data, appId, keyId, env);

--- a/test/server/_fakes/data/routes/application.js
+++ b/test/server/_fakes/data/routes/application.js
@@ -24,7 +24,10 @@ const routeData = {
     keyDescription: 'description',
     keyType: 'rest',
     restrictedIps: '00000',
-    javaScriptDomains: 'javascriptDomain'
+    javaScriptDomains: 'javascriptDomain',
+    appId: "app123",
+    env: "test",
+    keyId: "key123"
   }
 };
 

--- a/test/server/routes/applications.test.js
+++ b/test/server/routes/applications.test.js
@@ -368,7 +368,7 @@ describe('routes/applications.js', () => {
   });
 
   it('should serve the update key page on the /manage-applications/:appId/:keyType/:keyId/update/:env with errors', () => {
-    const slug = '/manage-applications/mockAppId/mockKeyType/mockKeyId/update/mockEnv';
+    const slug = '/manage-applications/app123/rest/key123/update/test';
     const stubValidatorError = sinon.stub(Validator.prototype, 'updateKey').rejects(new Error('Validation error'));
     const stubProcessException = sinon.stub(routeUtils, 'processException').returns(exceptions.validationException.stack);
     const stubUpdate = sinon.stub(ApplicationsDeveloperService.prototype, 'updateKey').returns(Promise.resolve(true));


### PR DESCRIPTION
…following request can still be routed