### PR TITLE
fix: remove redundant aria controls attribute

### DIFF
--- a/server/views/applications/add.njk
+++ b/server/views/applications/add.njk
@@ -43,7 +43,7 @@
       {% endif %}
       <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="testEnvironment" name="environment" type="radio" value="test" aria-controls="conditional-environment"{{ ' checked="checked"' if this_data.environment === 'test' }} />
+          <input class="govuk-radios__input" id="testEnvironment" name="environment" type="radio" value="test"{{ ' checked="checked"' if this_data.environment === 'test' }} />
           <label class="govuk-label govuk-radios__label" for="testEnvironment">Test</label>
         </div>
         {% if FUTURE_DISPLAY_FLAG === 'true' %}


### PR DESCRIPTION
Aria-controls appears to be a redundant attribute for the functionality of this feature, so it has been removed.