### PR TITLE
Alter the client secret JavaScript for browsers that don't support -webkit-text-security

### DIFF
--- a/app/public/css/app.css
+++ b/app/public/css/app.css
@@ -38,12 +38,12 @@
   border-color:#00703c;
   padding: 1em;
 }
+#client-secret-item {
+    padding-right: 0;
+  }
 
-.client-secret-item {
-  padding-right: 0;
-}
-#client-secret-display {
-  border:none;
-  background-color:white;
-  width: 100%;
-}
+.client-secret-display {
+    border: none;
+    background-color: white;
+    width: 100%;
+  }

--- a/app/public/css/app.css
+++ b/app/public/css/app.css
@@ -38,3 +38,12 @@
   border-color:#00703c;
   padding: 1em;
 }
+
+.client-secret-item {
+  padding-right: 0;
+}
+#client-secret-display {
+  border:none;
+  background-color:white;
+  width: 100%;
+}

--- a/app/public/css/app.css
+++ b/app/public/css/app.css
@@ -38,10 +38,9 @@
   border-color:#00703c;
   padding: 1em;
 }
-#client-secret-item {
+.client-secret-item {
     padding-right: 0;
   }
-
 .client-secret-display {
     border: none;
     background-color: white;

--- a/app/src/js/__global.js
+++ b/app/src/js/__global.js
@@ -41,9 +41,9 @@ function showElementById (id) {
 }
 
 function changeFieldSecurity (fieldId) {
-  var security = document.getElementById(fieldId).getAttribute('type');
+  var displayType = document.getElementById(fieldId).getAttribute('type');
   var linkId = fieldId + '-link';
-  if (security === 'password') {
+  if (displayType === 'password') {
     document.getElementById(fieldId).setAttribute('type', 'text');
     document.getElementById(linkId).innerHTML = 'Hide<span class="govuk-visually-hidden"> key</span>';
   } else {

--- a/app/src/js/__global.js
+++ b/app/src/js/__global.js
@@ -41,13 +41,13 @@ function showElementById (id) {
 }
 
 function changeFieldSecurity (fieldId) {
-  var security = document.getElementById(fieldId).style.webkitTextSecurity;
+  var security = document.getElementById(fieldId).getAttribute('type');
   var linkId = fieldId + '-link';
-  if (security !== 'none') {
-    document.getElementById(fieldId).style.webkitTextSecurity = 'none';
+  if (security === 'password') {
+    document.getElementById(fieldId).setAttribute('type', 'text');
     document.getElementById(linkId).innerHTML = 'Hide<span class="govuk-visually-hidden"> key</span>';
   } else {
-    document.getElementById(fieldId).style.webkitTextSecurity = 'disc';
+    document.getElementById(fieldId).setAttribute('type', 'password');
     document.getElementById(linkId).innerHTML = 'Show<span class="govuk-visually-hidden"> key</span>';
   }
 }

--- a/server/views/applications/view.njk
+++ b/server/views/applications/view.njk
@@ -96,14 +96,14 @@
         {% if key.kind === 'api-client#web' %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            <label for="{{ key.id+"-secret" }}">Client Secret</label>
+            <label for="{{ loop.index }}">Client Secret</label>
           </dt>
-          <dd class="govuk-summary-list__value" style="padding-right: 0">
-            <input type="password" class="api-value client-secret-display" style="border:none; background-color:white; width: 100%;" id="{{ key.id+"-secret" }}" value="{{ key.clientSecret }}" disabled>
+          <dd class="govuk-summary-list__value" id="client-secret-item" style="padding-right: 0">
+            <input type="password" class="api-value client-secret-display" style="border:none; background-color:white; width: 100%;" id="{{ loop.index }}" value="{{ key.clientSecret }}" disabled>
           </dd>
-          <dd class="govuk-summary-list__actions" id="client-secret-item">
+          <dd class="govuk-summary-list__actions">
             <p class="govuk-body govuk-!-font-size-16">
-              <a href="javascript:void(0);" onclick={{ "changeFieldSecurity('"+key.id+"-secret');" }} id={{ key.id+"-secret-link" }}>Show<span class="govuk-visually-hidden"> key</span></a>
+              <a href="javascript:void(0);" onclick={{ "changeFieldSecurity('"+loop.index+"');" }} id={{ loop.index+"-link" }}>Show<span class="govuk-visually-hidden"> key</span></a>
             </p>
             <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0">
               <a class="govuk-link" href="#">Copy<span class="govuk-visually-hidden">key</span>

--- a/server/views/applications/view.njk
+++ b/server/views/applications/view.njk
@@ -98,8 +98,8 @@
           <dt class="govuk-summary-list__key">
             <label for="{{ loop.index }}">Client Secret</label>
           </dt>
-          <dd class="govuk-summary-list__value" id="client-secret-item" style="padding-right: 0">
-            <input type="password" class="api-value client-secret-display" style="border:none; background-color:white; width: 100%;" id="{{ loop.index }}" value="{{ key.clientSecret }}" disabled>
+          <dd class="govuk-summary-list__value client-secret-item">
+            <input type="password" class="api-value client-secret-display" id="{{ loop.index }}" value="{{ key.clientSecret }}" disabled>
           </dd>
           <dd class="govuk-summary-list__actions">
             <p class="govuk-body govuk-!-font-size-16">

--- a/server/views/applications/view.njk
+++ b/server/views/applications/view.njk
@@ -99,9 +99,9 @@
             <label for="{{ key.id+"-secret" }}">Client Secret</label>
           </dt>
           <dd class="govuk-summary-list__value" style="padding-right: 0">
-            <input type="password" class="api-value" style="border:none; background-color:white; width: 100%; " id="{{ key.id+"-secret" }}" value="{{ key.clientSecret }}" disabled>
+            <input type="password" class="api-value client-secret-display" style="border:none; background-color:white; width: 100%;" id="{{ key.id+"-secret" }}" value="{{ key.clientSecret }}" disabled>
           </dd>
-          <dd class="govuk-summary-list__actions">
+          <dd class="govuk-summary-list__actions" id="client-secret-item">
             <p class="govuk-body govuk-!-font-size-16">
               <a href="javascript:void(0);" onclick={{ "changeFieldSecurity('"+key.id+"-secret');" }} id={{ key.id+"-secret-link" }}>Show<span class="govuk-visually-hidden"> key</span></a>
             </p>

--- a/server/views/applications/view.njk
+++ b/server/views/applications/view.njk
@@ -96,10 +96,10 @@
         {% if key.kind === 'api-client#web' %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Client Secret
+            <label for="{{ key.id+"-secret" }}">Client Secret</label>
           </dt>
-          <dd class="govuk-summary-list__value">
-            <span class="api-value" style="-webkit-text-security: disc;" id={{ key.id+"-secret" }}>{{ key.clientSecret }}</span>
+          <dd class="govuk-summary-list__value" style="padding-right: 0">
+            <input type="password" class="api-value" style="border:none; background-color:white; width: 100%; " id="{{ key.id+"-secret" }}" value="{{ key.clientSecret }}" disabled>
           </dd>
           <dd class="govuk-summary-list__actions">
             <p class="govuk-body govuk-!-font-size-16">


### PR DESCRIPTION
- added input tag that will switch between password and text for the hide/show client secret to make it more browser friendly
- Added label to client secret text in order to clear up html validation errors

Jira ticket: https://companieshouse.atlassian.net/browse/FA-997