### PR TITLE
bug: correct env variable handling for session imports

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -61,7 +61,7 @@ const middleware = SessionMiddleware({
   cookieName: process.env.COOKIE_NAME,
   cookieDomain: process.env.COOKIE_DOMAIN,
   cookieSecureFlag: process.env.COOKIE_SECURE_ONLY,
-  cookieTimeToLiveInSeconds: process.env.DEFAULT_SESSION_EXPIRATION,
+  cookieTimeToLiveInSeconds: parseInt(process.env.DEFAULT_SESSION_EXPIRATION, 10),
   cookieSecret: process.env.COOKIE_SECRET
 }, sessionStore);
 

--- a/test/server/routes/applications.test.js
+++ b/test/server/routes/applications.test.js
@@ -21,6 +21,7 @@ let stubLogger;
 let app;
 
 const signedInCookie = [`${process.env.COOKIE_NAME}=${SIGNED_IN_COOKIE}`];
+process.env.DEFAULT_SESSION_EXPIRATION = 3600;
 
 describe('routes/applications.js', () => {
   beforeEach(done => {


### PR DESCRIPTION
Corrected configuration of default session expiry to treat it as an integer rather than a string.