### PR TITLE
fa-1062 api client key bug fix

### DIFF
--- a/server/lib/Utility.js
+++ b/server/lib/Utility.js
@@ -33,19 +33,27 @@ class Utility {
 
   /**
    * Retrieve the oauth access token from a request
-   *  
+   *
    * @param {req} request
    */
   static getOAuthToken (req) {
     const signinInfo = req.session.data.signin_info;
-    if ( !signinInfo ) {
+    if (!signinInfo) {
       return;
     }
     const accessToken = signinInfo.access_token;
-    if ( !accessToken ) {
-      return
+    if (!accessToken) {
+      return;
     }
     return accessToken.access_token;
+  }
+
+  static splitString (string) {
+    if (string === null | string === '') {
+      return [];
+    } else {
+      return string.split(',');
+    }
   }
 }
 

--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -307,8 +307,8 @@ router.get('/manage-applications/:appId/:keyType/:keyId/update/:env', (req, res,
         viewData.this_data.javaScriptDomains = keyData.jsDomains;
       } else if (keyType === 'web') {
         viewData.this_data.redirectURIs = keyData.redirectURIs;
-      } else if (keyType === 'stream') {
-        viewData.this_data.restrictedIps = keyData.restrictedIPs;
+      } else if (keyType === 'stream-key') {
+        logger.info('VIEW DATA IPS ', viewData.this_data.restrictedIps);
       }
       res.render(`${routeViews}/update_key.njk`, viewData);
     }).catch(err => {

--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -308,7 +308,7 @@ router.get('/manage-applications/:appId/:keyType/:keyId/update/:env', (req, res,
       } else if (keyType === 'web') {
         viewData.this_data.redirectURIs = keyData.redirectURIs;
       } else if (keyType === 'stream-key') {
-        logger.info('VIEW DATA IPS ', viewData.this_data.restrictedIps);
+        viewData.this_data.restrictedIps = keyData.restrictedIPs;
       }
       res.render(`${routeViews}/update_key.njk`, viewData);
     }).catch(err => {

--- a/server/services/ApplicationsDeveloper.js
+++ b/server/services/ApplicationsDeveloper.js
@@ -1,5 +1,6 @@
 const logger = require(`${serverRoot}/config/winston`);
 const APIClientHelper = require(`${serverRoot}/lib/APIClientHelper`);
+const utility = require(`${serverRoot}/lib/Utility`);
 
 class ApplicationsDeveloper {
   constructor () {
@@ -102,8 +103,8 @@ class ApplicationsDeveloper {
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
     let restrictedIps = [];
     let javaScriptDomains = [];
-    restrictedIps = data.restrictedIps.split(',');
-    javaScriptDomains = data.javaScriptDomains.split(',');
+    restrictedIps = utility.splitString(data.restrictedIps);
+    javaScriptDomains = utility.splitString(data.javaScriptDomains);
     const apiKeyPostRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -128,7 +129,7 @@ class ApplicationsDeveloper {
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
 
     let redirectURIs = [];
-    redirectURIs = data.redirectURIs.split(',');
+    redirectURIs = utility.splitString(data.redirectURIs);
     const webClientPostRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -150,9 +151,8 @@ class ApplicationsDeveloper {
     logger.info(
       `creating stream key for application=[${appId}] in environment=[${environment}], using serverUrl=[${serverUrl}]`);
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
-
     let restrictedIps = [];
-    restrictedIps = data.restrictedIps.split(',');
+    restrictedIps = utility.splitString(data.restrictedIps);
     const streamKeyPostRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -187,7 +187,7 @@ class ApplicationsDeveloper {
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
 
     let redirectURIs = [];
-    redirectURIs = data.redirectURIs.split(',');
+    redirectURIs = utility.splitString(data.redirectURIs);
     const apiKeyPutRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -201,13 +201,12 @@ class ApplicationsDeveloper {
     return apiKey.resource;
   }
 
-
   async updateStreamKey (data, appId, keyId, oauthToken, environment) {
     const serverUrl = this.server.baseUrl[environment];
     logger.info(`updating stream key=[${keyId}] for application=[${appId}] in environment=[${environment}], using serverUrl=[${serverUrl}]`);
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
     let restrictedIps = [];
-    restrictedIps = data.restrictedIps.split(',');
+    restrictedIps = utility.splitString(data.restrictedIps);
     const streamKeyPutRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -227,8 +226,8 @@ class ApplicationsDeveloper {
     const client = APIClientHelper.getPrivateAPIClient(oauthToken, serverUrl);
     let restrictedIps = [];
     let javaScriptDomains = [];
-    restrictedIps = data.restrictedIps.split(',');
-    javaScriptDomains = data.javaScriptDomains.split(',');
+    restrictedIps = utility.splitString(data.restrictedIps);
+    javaScriptDomains = utility.splitString(data.javaScriptDomains);
     const apiKeyPutRequest = {
       name: data.keyName,
       description: data.keyDescription,
@@ -314,7 +313,7 @@ class ApplicationsDeveloper {
       apiClient = await client.streamKeysService.deleteStreamKey(appId, keyId);
     } else if (keyType === 'web') {
       apiClient = await client.webClientsService.deleteWebClient(appId, keyId);
-    } else if (keyType == 'key') {
+    } else if (keyType === 'key') {
       apiClient = await client.apiKeysService.deleteAPIKey(appId, keyId);
     } else {
       logger.info(`Cannot delete Key of Type: ${keyType}`);

--- a/test/server/lib/Utility.test.js
+++ b/test/server/lib/Utility.test.js
@@ -4,6 +4,9 @@ describe('lib/Utility', () => {
 
   const ModuleUnderTest = require(`${serverRoot}/lib/Utility`);
 
+  const chai = require('chai');
+  const assert = chai.assert;
+
   beforeEach(() => {
     sinon.reset();
     sinon.restore();
@@ -44,6 +47,27 @@ describe('lib/Utility', () => {
       const stubLogger = sinon.stub(logger, 'error').returns(true);
       expect(ModuleUnderTest.logException(exceptionWithNoStatus)).to.be.undefined;
       expect(stubLogger).to.have.been.calledOnce;
+    });
+
+    it('splitString should return the string as an array with one entry', () => {
+      const restrictedIp = '1.1.1';
+      const expected = ['1.1.1'];
+      const actual = ModuleUnderTest.splitString(restrictedIp);
+      assert.equal(expected.length, actual.length);
+      assert.equal(expected[0], actual[0]);
+    });
+
+    it('splitString should return the string as an array with two entries', () => {
+      const restrictedIp = '1.1.1.1,2.2.2.2';
+      const expected = ['1.1.1.1', '2.2.2.2'];
+      const actual = ModuleUnderTest.splitString(restrictedIp);
+      assert.equal(expected.length, actual.length);
+    });
+
+    it('splitString should return an empty array when a null value is passed;', () => {
+      const restrictedIp = null;
+      const emptyArray = ModuleUnderTest.splitString(restrictedIp);
+      assert.isEmpty(emptyArray);
     });
   });
 });

--- a/test/server/services/ApplicationDeveloper.test.js
+++ b/test/server/services/ApplicationDeveloper.test.js
@@ -395,7 +395,7 @@ describe('services/ApplicationDeveloper', () => {
     // Call method
     const returnedPromise = applicationDeveloper.updateKey(data, mockAppId, mockKeyId, mockKeyType, mockOauthToken, mockEnv);
     returnedPromise.should.be.rejectedWith('Could not match Key Type');
-  })
+  });
 
   it('should update a rest key using the applications.api service', () => {
     // static test vars
@@ -470,9 +470,9 @@ describe('services/ApplicationDeveloper', () => {
     expect(applicationDeveloper.updateWebKey(data, mockAppId, mockKeyId, mockOauthToken, mockEnv))
       // Assertions
       .to.eventually.eql(privateSdkData.getWebClient.resource);
-      expect(stubAPIClientHelper).to.have.been.calledOnce;
-      expect(stubLogger).to.have.been.calledTwice;
-    });
+    expect(stubAPIClientHelper).to.have.been.calledOnce;
+    expect(stubLogger).to.have.been.calledTwice;
+  });
 
   it('should update a stream key using the applications.api service', () => {
     // static test vars


### PR DESCRIPTION
-added new method to split the string for multiple entries while ensuring that blank values are saved correctly to the database.
-altered tests to reflect the changes.
-added new tests for the new method.
-fixed miscellaneous errors.
-fixed an error with the stream key not displaying ips correctly when updating a key.

jira ticket: https://companieshouse.atlassian.net/browse/FA-1062